### PR TITLE
Close #8. Add Spotify service for recommeded artists

### DIFF
--- a/app/services/spotify/service.rb
+++ b/app/services/spotify/service.rb
@@ -4,6 +4,14 @@ class Spotify::Service < Spotify::Base
     @connection = initialize_connection
   end
 
+  def recommended_artists(top_5_artist_ids)
+    response = connection.get('/v1/recommendations') do |request|
+      request.params[:seed_artists] = top_5_artist_ids
+      request.params[:limit] = 50
+    end
+    parse(response.body)[:tracks]
+  end
+
   def top_25_artists(time_range)
     response = connection.get('/v1/me/top/artists') do |request|
       request.params[:limit] = 25

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,7 +18,7 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = "spec/vcr_cassettes"
   config.hook_into :webmock
-  config.ignore_host 'https://accounts.spotify.com/api/token'
+  config.allow_http_connections_when_no_cassette = true
 end
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -54,6 +54,23 @@ RSpec.describe 'Spotify service' do
       end
     end
   end
+
+  context '#recommended_artists' do
+    it "gets a user's recommended artists" do
+      VCR.use_cassette('spotify_service_recommended_artists') do
+        artist_ids = "4MXUO7sVCaFgFjoTI5ox5c," \
+                     "39vm4qt0PqnZrJOoA9FXTD," \
+                     "5SjNVG3L9mgWQPsfp1sFDB," \
+                     "0IlQRCafsMrd0QkTRBU6n0," \
+                     "7z1QgLoFoyVn2Ra22w8Wzo"
+        recommended = Spotify::Service.new(ENV['ACCESS_TOKEN'])
+                                      .recommended_artists(artist_ids)
+
+        expect(recommended.length).to eq(50)
+        expect(recommended.first[:artists].first[:name]).to eq('Warpaint')
+      end
+    end
+  end
 end
 
 def token_expired?


### PR DESCRIPTION
- Add method in service
- Add test
- Update config for VCR to allow http requests without a cassette