### PR TITLE
Close #19. Close #20. Add recommended artists

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -29,6 +29,15 @@ class Artist
     compose_complete_artists_in_parallel(artists)
   end
 
+  def self.recommended(current_user, top_artists)
+    artists = RecommendationEngine.new(current_user, top_artists)
+                                  .unique_recommended
+    artists.map do |artist|
+      artist[:weight] = 26
+      Artist.new(artist: artist, songkick: {})
+    end
+  end
+
   def name
     artist[:name]
   end
@@ -83,6 +92,10 @@ class Artist
     end
     threads.each(&:join)
     complete_artists.sort_by!(&:weight)
+  end
+
+  def id
+    artist[:id]
   end
 
   private

--- a/app/models/recommendation_engine.rb
+++ b/app/models/recommendation_engine.rb
@@ -1,0 +1,33 @@
+class RecommendationEngine
+  def initialize(user, top_artists)
+    @user = user
+    @top_artists = top_artists
+  end
+
+  def unique_recommended
+    recommended_artists.map do |track|
+      unless top_artists_names.include?(track[:artists].first[:name])
+        track[:artists].first
+      end
+    end.compact
+  end
+
+  private
+
+  attr_reader :user,
+              :top_artists
+
+  def top_5_artists_ids
+    top_artists[0..4].map(&:id).join(',')
+  end
+
+  def top_artists_names
+    top_artists.map(&:name)
+  end
+
+  def recommended_artists
+    Spotify::Service.new(user.access_token)
+                    .recommended_artists(top_5_artists_ids)
+                    .uniq { |track| track[:artists].first[:name] }
+  end
+end

--- a/app/services/spotify/service.rb
+++ b/app/services/spotify/service.rb
@@ -7,7 +7,7 @@ class Spotify::Service < Base
   def recommended_artists(top_5_artist_ids)
     response = connection.get('/v1/recommendations') do |request|
       request.params[:seed_artists] = top_5_artist_ids
-      request.params[:limit] = 50
+      request.params[:limit] = 100
     end
     parse(response.body)[:tracks]
   end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -44,4 +44,26 @@ describe Artist do
       expect(top_artists.first.on_tour?).to be_falsy
     end
   end
+
+  it "gets a user's unique recommended, weighted artists" do
+    VCR.use_cassette('artist_recommended_artists') do
+      user = create(
+        :user,
+        access_token: ENV['ACCESS_TOKEN'],
+        refresh_token: ENV['REFRESH_TOKEN'],
+        token_expiry: ENV['TOKEN_EXPIRY']
+      )
+
+      top_artists = Artist.top_spotify_artists(user, 'long_term')
+      recommended = Artist.recommended(user, top_artists)
+
+      expect(recommended.length).to be > 24
+      expect(recommended.first).to be_a(Artist)
+      expect(recommended.first.name).to be_a(String)
+      expect(recommended.first.weight).to eq(26)
+      expect(recommended.last.weight).to eq(26)
+      expect(recommended.uniq(&:name).length)
+        .to eq(recommended.length)
+    end
+  end
 end

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Spotify service' do
         recommended = Spotify::Service.new(ENV['ACCESS_TOKEN'])
                                       .recommended_artists(artist_ids)
 
-        expect(recommended.length).to eq(50)
+        expect(recommended.length).to eq(100)
         expect(recommended.first[:artists].first[:name])
           .to eq('Sufjan Stevens')
       end


### PR DESCRIPTION
- Artist model can now return unique, weighted recommended artists
- Top artists are excluded from the recommended artists (Spotify returns recommended tracks, so a top artist can easily appear)