### PR TITLE
Close #41. Add playlist functionality.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'faraday'
 gem 'twitter-bootstrap-rails'
 gem 'redis'
 gem 'redis-rails'
-# gem 'sidekiq'
+gem 'sidekiq'
 gem 'typhoeus'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
     coffee-script-source (1.10.0)
     commonjs (0.2.7)
     concurrent-ruby (1.0.2)
+    connection_pool (2.2.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.3)
@@ -207,6 +208,10 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    sidekiq (4.1.1)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      redis (~> 3.2, >= 3.2.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -275,6 +280,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   shoulda-matchers
+  sidekiq
   simplecov
   twitter-bootstrap-rails
   typhoeus

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec rails server -p $PORT
+worker: bundle exec sidekiq

--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -76,7 +76,7 @@ function fourWeekArtistsButton(){
     event.preventDefault();
     $('#top-artists-header').hide().html('Top Spotify Artists - Last 4 Weeks').fadeIn('slow');
     fetchArtists('short_term');
-  })
+  });
 }
 
 function sixMonthArtistsButton(){
@@ -118,9 +118,9 @@ function collectArtists(artistsData){
 
 function createArtistHTML(artist){
   return $(
-    "<div class='col-md-3 artist text-center'>"
-    + artist.name
-    + "</div>"
+    "<div class='col-md-3 artist text-center'>" +
+    artist.name +
+    "</div>"
   );
 }
 
@@ -130,25 +130,44 @@ function renderArtists(artistsData){
 
 function createFestHTML(fest, index){
   return(
-    "<tr id='fest-"
-    + index + 1
-    + "'>"
-    + "<td class='table-body-default'>" + (index + 1) + "</td>"
-    + "<td class='table-fest-link'><a href='" + fest.url + "' title='View this festival on Songkick' target='_blank'>" + fest.name + "</a></td>"
-    + "<td class='table-fest-location'>" + fest.location + "</td>"
-    + "<td class= 'table-fest-dates'>" + fest.start_date + " - " + fest.end_date + "</td>"
-    + "<td class='table-artists'>" + preRenderFestArtists(fest.top_artists) + "</td>"
-    + "<td class='table-artists'>" + preRenderFestArtists(fest.rec_artists) + "</td>"
-    + "<td class='table-other-artists'><a href='" + fest.url + "' title='View all artists for this festival on Songkick' target='_blank'>" + fest.other_artists_count + "+</a></td>"
-    + "<td class='table-playlist'><button class='playlist'>Follow</button></td>"
-    + "</tr>"
-  )
+    "<tr id='fest-" +
+    index + 1 +
+    "'>" +
+    "<td class='table-body-default'>" + (index + 1) + "</td>" +
+    "<td class='table-fest-link'><a href='" + fest.url + "' title='View this festival on Songkick' target='_blank'>" + fest.name + "</a></td>" +
+    "<td class='table-fest-location'>" + fest.location + "</td>" +
+    "<td class= 'table-fest-dates'>" + fest.start_date + " - " + fest.end_date + "</td>" +
+    "<td class='table-artists'>" + preRenderFestArtists(fest.top_artists) + "</td>" +
+    "<td class='table-artists'>" + preRenderFestArtists(fest.rec_artists) + "</td>" +
+    "<td class='table-other-artists'><a href='" + fest.url + "' title='View all artists for this festival on Songkick' target='_blank'>" + fest.other_artists_count + "+</a></td>" +
+    "<td class='table-playlist'><button class='playlist' disabled='true'>Loading...</button></td>" +
+    "</tr>"
+  );
+}
+
+function setButtonText(fests) {
+  $('.playlist').each(function(_index, button){
+    var $button = $(button);
+    var fest = $button.closest('tr').find('.table-fest-link').text();
+    $.ajax({
+      url: '/playlists/' + fest
+    })
+    .then(setFollowText.bind(this, $button))
+    .fail(handleError);
+  });
+}
+
+function setFollowText(button, response) {
+  var text = response.playlist.followed ? 'Unfollow' : 'Follow';
+  button.text(text);
+  button.attr('class', 'playlist ' + text.toLowerCase());
+  button.prop('disabled', false);
 }
 
 function preRenderFestArtists(artists) {
   return artists.map(function(artist) {
-    return artist.name + "<br>"
-  }).join('')
+    return artist.name + "<br>";
+  }).join('');
 }
 
 function renderFestivals(festivalsData){
@@ -156,14 +175,32 @@ function renderFestivals(festivalsData){
   loadingStatusCleanup();
   $('#top-festivals').show();
   $('#songkick').fadeIn('fast');
+  setButtonText(festivalsData);
   followButtons();
 }
 
 function followButtons() {
   $('.playlist').on('click', function(e){
     e.preventDefault();
-    var fest = $(e.target).closest('tr').find('.table-fest-link').text()
+    var $button = $(e.target);
+    var fest = $button.closest('tr').find('.table-fest-link').text();
+    $button.prop('disabled', true);
+    $.ajax({
+      type: 'PUT',
+      url: '/playlists/' + fest,
+      data: { playlist: { text: $button.text() } }
+    })
+    .then(updateButton.bind(this, $button))
+    .fail(handleError);
   });
+}
+
+function updateButton(button, _response) {
+  var existingText = button.text();
+  var newText = existingText === 'Follow' ? 'Unfollow' : 'Follow';
+  button.text(newText);
+  button.attr('class', 'playlist ' + newText.toLowerCase());
+  button.prop('disabled', false);
 }
 
 function loadingStatusCleanup(){

--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -130,8 +130,8 @@ function renderArtists(artistsData){
 
 function createFestHTML(fest, index){
   return(
-    "<tr id='fest-" +
-    index + 1 +
+    "<tr id='fest-0" +
+    (index + 1) +
     "'>" +
     "<td class='table-body-default'>" + (index + 1) + "</td>" +
     "<td class='table-fest-link'><a href='" + fest.url + "' title='View this festival on Songkick' target='_blank'>" + fest.name + "</a></td>" +

--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -140,6 +140,7 @@ function createFestHTML(fest, index){
     + "<td class='table-artists'>" + preRenderFestArtists(fest.top_artists) + "</td>"
     + "<td class='table-artists'>" + preRenderFestArtists(fest.rec_artists) + "</td>"
     + "<td class='table-other-artists'><a href='" + fest.url + "' title='View all artists for this festival on Songkick' target='_blank'>" + fest.other_artists_count + "+</a></td>"
+    + "<td class='table-playlist'><button class='playlist'>Follow</button></td>"
     + "</tr>"
   )
 }
@@ -155,6 +156,14 @@ function renderFestivals(festivalsData){
   loadingStatusCleanup();
   $('#top-festivals').show();
   $('#songkick').fadeIn('fast');
+  followButtons();
+}
+
+function followButtons() {
+  $('.playlist').on('click', function(e){
+    e.preventDefault();
+    var fest = $(e.target).closest('tr').find('.table-fest-link').text()
+  });
 }
 
 function loadingStatusCleanup(){

--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -97,3 +97,25 @@ tbody {
 .progress-bar-danger {
   background-color: black;
 }
+
+.table-playlist {
+  text-align: center;
+}
+
+.playlist {
+  border-color: #26215C;
+  border-radius: 8px;
+  background-color: inherit;
+}
+
+.playlist:hover {
+  border-color: white;
+  background-color: #26215C;
+  color: white;
+}
+
+.playlist:active {
+  border-color: #26215C;
+  background-color: inherit;
+  color: inherit;
+}

--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -119,3 +119,9 @@ tbody {
   background-color: inherit;
   color: inherit;
 }
+
+.playlist:disabled {
+  border-color: gray;
+  color: gray;
+  background-color: lightgray;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,13 +8,12 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
-  def refresh_expired_token
-    if current_user && current_user.token_expiry < Time.now
-      tokens = Spotify::AuthService.new
-                                   .refresh_user_tokens(
-                                     current_user.refresh_token
-                                   )
-      current_user.update(tokens)
-    end
+  def site_admin
+    @site_admin ||= User.site_admin
+  end
+
+  def refresh_expired_tokens
+    UserEngine.update_user(current_user)
+    UserEngine.update_user(site_admin)
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,5 @@
 class HomeController < ApplicationController
-  before_action :refresh_expired_token
+  before_action :refresh_expired_tokens
 
   def index
   end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -1,0 +1,20 @@
+class PlaylistsController < ApplicationController
+  def show
+    @playlist = Playlist.find_by_name(params[:name])
+    if @playlist.nil?
+      render json: { playlist: { followed: false } }
+    end
+  end
+
+  def update
+    festival = Rails.cache.fetch(params[:name])
+    playlist = Playlist.find_or_create(festival)
+    playlist.process_follow(current_user, playlist_params[:text])
+  end
+
+  private
+
+  def playlist_params
+    params.require(:playlist).permit(:text);
+  end
+end

--- a/app/controllers/spotify_auth_controller.rb
+++ b/app/controllers/spotify_auth_controller.rb
@@ -10,6 +10,6 @@ class SpotifyAuthController < ApplicationController
     "client_id=#{ENV['SPOTIFY_CLIENT']}&" \
     'response_type=code' \
     "&redirect_uri=#{ENV['SPOTIFY_REDIRECT']}&" \
-    'scope=user-top-read'
+    'scope=user-top-read playlist-modify-public'
   end
 end

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -4,7 +4,7 @@ class Festival
               :rec_artists,
               :festival
 
-  def initialize(params, data=nil)
+  def initialize(params, data={})
     @festival = params
     @score = data[:score]
     @top_artists = data[:top_artists]

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -18,11 +18,9 @@ class Festival
       Rails.cache.fetch(festival[:displayName], expires_in: 1.hour) do
         Festival.new(
           festival,
-          {
-            score: festival[:score],
-            top_artists: festival[:top_artists],
-            rec_artists: festival[:rec_artists]
-          }
+          score: festival[:score],
+          top_artists: festival[:top_artists],
+          rec_artists: festival[:rec_artists]
         )
       end
     end

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -1,13 +1,15 @@
 class Festival
   attr_reader :score,
               :top_artists,
-              :rec_artists
+              :rec_artists,
+              :playlist
 
-  def initialize(params, score=nil, top_artists=nil, rec_artists=nil)
+  def initialize(params, data=nil)
     @festival = params
-    @score = score
-    @top_artists = top_artists
-    @rec_artists = rec_artists
+    @score = data[:score]
+    @top_artists = data[:top_artists]
+    @rec_artists = data[:rec_artists]
+    @playlist = data[:playlist]
   end
 
   def self.top_festivals(all_artists)
@@ -16,9 +18,12 @@ class Festival
     festivals.map do |festival|
       Festival.new(
         festival,
-        festival[:score],
-        festival[:top_artists],
-        festival[:rec_artists]
+        {
+          score: festival[:score],
+          top_artists: festival[:top_artists],
+          rec_artists: festival[:rec_artists],
+          playlist: Playlist.find_or_create(festival)
+        }
       )
     end
   end

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -1,4 +1,11 @@
 class Playlist < ApplicationRecord
   validates :name, presence: true
   validates :spotify_id, presence: true, uniqueness: true
+
+  def self.find_or_create(festival_data)
+    festival_name = festival_data[:displayName]
+    find_or_create_by(name: festival_name) do |playlist|
+      playlist.spotify_id = PlaylistEngine.new(festival_data).id
+    end
+  end
 end

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -1,0 +1,4 @@
+class Playlist < ApplicationRecord
+  validates :name, presence: true
+  validates :spotify_id, presence: true, uniqueness: true
+end

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -8,7 +8,7 @@ class Playlist < ApplicationRecord
     end
   end
 
-  def is_followed?(user)
+  def followed?(user)
     Spotify::Service.new(user.access_token)
                     .user_following_playlist?(
                       user.username,

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -2,10 +2,26 @@ class Playlist < ApplicationRecord
   validates :name, presence: true
   validates :spotify_id, presence: true, uniqueness: true
 
-  def self.find_or_create(festival_data)
-    festival_name = festival_data[:displayName]
-    find_or_create_by(name: festival_name) do |playlist|
-      playlist.spotify_id = PlaylistEngine.new(festival_data).id
+  def self.find_or_create(festival)
+    find_or_create_by(name: festival.name) do |playlist|
+      playlist.spotify_id = PlaylistEngine.new(festival).id
+    end
+  end
+
+  def is_followed?(user)
+    Spotify::Service.new(user.access_token)
+                    .user_following_playlist?(
+                      user.username,
+                      spotify_id
+                    )
+  end
+
+  def process_follow(user, current_status)
+    service = Spotify::Service.new(user.access_token)
+    if current_status == 'Unfollow'
+      service.unfollow_playlist(spotify_id)
+    else
+      service.follow_playlist(spotify_id)
     end
   end
 end

--- a/app/models/playlist_engine.rb
+++ b/app/models/playlist_engine.rb
@@ -3,10 +3,10 @@ class PlaylistEngine
 
   PLAYLIST_MAX = 100
 
-  def initialize(festival_data)
-    @all_artists = artist_names(festival_data)
+  def initialize(festival)
+    @all_artists = artist_names(festival.festival)
     @service = Spotify::Service.new(User.site_admin.access_token)
-    @id = create_playlist(festival_data[:displayName])
+    @id = create_playlist(festival.name)
     PlaylistWorker.perform_async(id, all_artists)
   end
 

--- a/app/models/playlist_engine.rb
+++ b/app/models/playlist_engine.rb
@@ -7,11 +7,7 @@ class PlaylistEngine
     @all_artists = artist_names(festival_data)
     @service = Spotify::Service.new(User.site_admin.access_token)
     @id = create_playlist(festival_data[:displayName])
-
-    # Need to revisit this - ideally the job will only execute once
-    # others are finished, currently playlists generate in isolation but
-    # not when processed multiple at a time.
-    PlaylistWorker.perform_in(rand(60).seconds, id, all_artists)
+    PlaylistWorker.perform_async(id, all_artists)
   end
 
   private

--- a/app/models/playlist_engine.rb
+++ b/app/models/playlist_engine.rb
@@ -1,0 +1,31 @@
+class PlaylistEngine
+  attr_reader :id
+
+  PLAYLIST_MAX = 100
+
+  def initialize(festival_data)
+    @all_artists = artist_names(festival_data)
+    @service = Spotify::Service.new(User.site_admin.access_token)
+    @id = create_playlist(festival_data[:displayName])
+
+    # Need to revisit this - ideally the job will only execute once
+    # others are finished, currently playlists generate in isolation but
+    # not when processed multiple at a time.
+    PlaylistWorker.perform_in(rand(60).seconds, id, all_artists)
+  end
+
+  private
+
+  attr_reader :service,
+              :all_artists
+
+  def create_playlist(festival_name)
+    service.create_playlist(festival_name)
+  end
+
+  def artist_names(festival_data)
+    festival_data[:performance].first(PLAYLIST_MAX).map do |artist|
+      artist[:displayName]
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,12 @@ class User < ApplicationRecord
     end
     user
   end
+
+  def self.site_admin
+    find_or_create_by(username: ENV['FS_ADMIN_NAME']) do |user|
+      user.access_token  = ENV['FS_ACCESS_TOKEN']
+      user.refresh_token = ENV['FS_REFRESH_TOKEN']
+      user.token_expiry  = Time.now - 3700
+    end
+  end
 end

--- a/app/models/user_engine.rb
+++ b/app/models/user_engine.rb
@@ -1,0 +1,28 @@
+class UserEngine
+  def initialize(user)
+    @user    = user
+    @service = Spotify::AuthService.new
+    update_user_tokens
+  end
+
+  def self.update_user(user)
+    new(user)
+  end
+
+  private
+
+  attr_reader :service,
+              :user
+
+  def token_expired?
+    user.token_expiry < Time.now
+  end
+
+  def get_new_tokens
+    service.refresh_user_tokens(user.refresh_token)
+  end
+
+  def update_user_tokens
+    user.update(get_new_tokens) if user && token_expired?
+  end
+end

--- a/app/services/spotify/service.rb
+++ b/app/services/spotify/service.rb
@@ -103,6 +103,39 @@ class Spotify::Service < Base
     end
   end
 
+  def user_following_playlist?(user_id, playlist_id)
+    request = Typhoeus::Request.new(
+      "#{base_url}/v1/users/#{ENV['FS_ADMIN_NAME']}/playlists/" \
+      "#{playlist_id}/followers/contains",
+      headers: headers,
+      params: { ids: user_id }
+    ).run
+
+    parse(request.response_body).first
+  end
+
+  def follow_playlist(playlist_id)
+    request = Typhoeus::Request.new(
+      "#{base_url}/v1/users/#{ENV['FS_ADMIN_NAME']}/playlists/" \
+      "#{playlist_id}/followers",
+      method: :put,
+      headers: {
+        'Authorization': headers[:Authorization],
+        'Content-Type': 'application/json'
+      },
+      body: { public: true }.to_json
+    ).run
+  end
+
+  def unfollow_playlist(playlist_id)
+    request = Typhoeus::Request.new(
+      "#{base_url}/v1/users/#{ENV['FS_ADMIN_NAME']}/playlists/" \
+      "#{playlist_id}/followers",
+      method: :delete,
+      headers: headers
+    ).run
+  end
+
   private
 
   attr_reader :base_url,

--- a/app/services/spotify/service.rb
+++ b/app/services/spotify/service.rb
@@ -60,8 +60,9 @@ class Spotify::Service < Base
 
     request_pool.run
 
-    requests.map do |request|
-      parse(request.response.body)[:tracks].first[:uri]
+    requests.reduce([]) do |uris, request|
+      parsed = parse(request.response.body)[:tracks]
+      parsed.empty? ? uris : uris << parsed.first[:uri]
     end
   end
 

--- a/app/services/spotify/service.rb
+++ b/app/services/spotify/service.rb
@@ -2,6 +2,7 @@ class Spotify::Service < Base
   def initialize(token)
     @base_url = 'https://api.spotify.com'
     @headers  = { 'Authorization': "Bearer #{token}" }
+    @request_pool = Typhoeus::Hydra.hydra
   end
 
   def recommended_artists(top_5_artist_ids)
@@ -33,10 +34,79 @@ class Spotify::Service < Base
     data[:display_name].nil? ? data[:id] : data[:display_name]
   end
 
+  def create_playlist(name)
+    request = Typhoeus::Request.new(
+      "#{base_url}/v1/users/#{ENV['FS_ADMIN_NAME']}/playlists",
+      method: :post,
+      headers: {
+        'Authorization': headers[:Authorization],
+        'Content-Type': 'application/json'
+      },
+      body: { name: name }.to_json
+    ).run
+    parse(request.response_body)[:id]
+  end
+
+  def each_artists_top_track(artist_ids)
+    requests = artist_ids.map do |id|
+      request = Typhoeus::Request.new(
+        "#{base_url}/v1/artists/#{id}/top-tracks",
+        headers: headers,
+        params: { country: 'US' }
+      )
+      request_pool.queue(request)
+      request
+    end
+
+    request_pool.run
+
+    requests.map do |request|
+      parse(request.response.body)[:tracks].first[:uri]
+    end
+  end
+
+  def add_tracks_to_playlist(playlist_id, tracks)
+    request = Typhoeus::Request.new(
+      "#{base_url}/v1/users/#{ENV['FS_ADMIN_NAME']}" \
+      "/playlists/#{playlist_id}/tracks",
+      method: :post,
+      headers: {
+        'Authorization': headers[:Authorization],
+        'Content-Type': 'application/json'
+      },
+      body: { uris: tracks }.to_json
+    ).run
+    parse(request.response_body)
+  end
+
+  def all_artist_ids(artist_names)
+    requests = artist_names.map do |name|
+      request = Typhoeus::Request.new(
+        "#{base_url}/v1/search?type=artist",
+        headers: headers,
+        params: {
+          q: name.gsub(' ', '+'),
+          type: 'artist',
+          limit: 1
+        }
+      )
+      request_pool.queue(request)
+      request
+    end
+
+    request_pool.run
+
+    requests.reduce([]) do |ids, request|
+      parsed = parse(request.response.body)[:artists][:items]
+      parsed.empty? ? ids : ids << parsed.first[:id]
+    end
+  end
+
   private
 
   attr_reader :base_url,
-              :headers
+              :headers,
+              :request_pool
 
   def request_user_data
     request = Typhoeus::Request.new(

--- a/app/services/spotify/service.rb
+++ b/app/services/spotify/service.rb
@@ -86,7 +86,7 @@ class Spotify::Service < Base
         "#{base_url}/v1/search?type=artist",
         headers: headers,
         params: {
-          q: name.gsub(' ', '+'),
+          q: name.tr(' ', '+'),
           type: 'artist',
           limit: 1
         }
@@ -115,7 +115,7 @@ class Spotify::Service < Base
   end
 
   def follow_playlist(playlist_id)
-    request = Typhoeus::Request.new(
+    Typhoeus::Request.new(
       "#{base_url}/v1/users/#{ENV['FS_ADMIN_NAME']}/playlists/" \
       "#{playlist_id}/followers",
       method: :put,
@@ -128,7 +128,7 @@ class Spotify::Service < Base
   end
 
   def unfollow_playlist(playlist_id)
-    request = Typhoeus::Request.new(
+    Typhoeus::Request.new(
       "#{base_url}/v1/users/#{ENV['FS_ADMIN_NAME']}/playlists/" \
       "#{playlist_id}/followers",
       method: :delete,

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -52,6 +52,7 @@
           <th>Top Artists</th>
           <th>Recommended Artists</th>
           <th>Other Artists</th>
+          <th>Spotify Playlist</th>
         </thead>
         <tbody id="top-fests-data">
         </tbody>

--- a/app/views/playlists/show.json.jbuilder
+++ b/app/views/playlists/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.playlist do
+  json.name @playlist.name
+  json.spotify_id @playlist.spotify_id
+  json.followed @playlist.is_followed?(current_user)
+end

--- a/app/views/playlists/show.json.jbuilder
+++ b/app/views/playlists/show.json.jbuilder
@@ -1,5 +1,5 @@
 json.playlist do
   json.name @playlist.name
   json.spotify_id @playlist.spotify_id
-  json.followed @playlist.is_followed?(current_user)
+  json.followed @playlist.followed?(current_user)
 end

--- a/app/workers/playlist_worker.rb
+++ b/app/workers/playlist_worker.rb
@@ -1,5 +1,6 @@
 class PlaylistWorker
   include Sidekiq::Worker
+  sidekiq_options concurrency: 1
 
   def perform(playlist_id, artist_names)
     service = Spotify::Service.new(User.site_admin.access_token)
@@ -19,6 +20,6 @@ class PlaylistWorker
     end
 
     service.add_tracks_to_playlist(playlist_id, top_tracks)
-    puts "Added tracks to playlist #{playlist_id}"
+    puts "Added #{top_tracks.length} tracks to playlist #{playlist_id}."
   end
 end

--- a/app/workers/playlist_worker.rb
+++ b/app/workers/playlist_worker.rb
@@ -1,0 +1,24 @@
+class PlaylistWorker
+  include Sidekiq::Worker
+
+  def perform(playlist_id, artist_names)
+    service = Spotify::Service.new(User.site_admin.access_token)
+    artist_ids = []
+    top_tracks = []
+
+    until artist_names.empty?
+      ids = service.all_artist_ids(artist_names.shift(25))
+      artist_ids.concat(ids)
+      sleep(15)
+    end
+
+    until artist_ids.empty?
+      tracks = service.each_artists_top_track(artist_ids.shift(25))
+      top_tracks.concat(tracks)
+      sleep(15)
+    end
+
+    service.add_tracks_to_playlist(playlist_id, top_tracks)
+    puts "Added tracks to playlist #{playlist_id}"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,8 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy', as: :logout
   resources :festivals, only: [:index], defaults: { format: 'json' }
   resources :artists, only: [:index], defaults: { format: 'json' }
+  resources :playlists,
+    only: [:show, :update],
+    param: :name,
+    defaults: { format: 'json' }
 end

--- a/db/migrate/20161207211030_create_playlists.rb
+++ b/db/migrate/20161207211030_create_playlists.rb
@@ -1,0 +1,8 @@
+class CreatePlaylists < ActiveRecord::Migration[5.0]
+  def change
+    create_table :playlists do |t|
+      t.text :name
+      t.text :spotify_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160922005319) do
+ActiveRecord::Schema.define(version: 20161207211030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "playlists", force: :cascade do |t|
+    t.text "name"
+    t.text "spotify_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.text     "username"

--- a/spec/features/user_logs_in_with_spotify_spec.rb
+++ b/spec/features/user_logs_in_with_spotify_spec.rb
@@ -42,14 +42,14 @@ RSpec.feature 'User logs in with Spotify' do
         .to receive(:request_user_data)
         .and_return(parsed_user_data)
 
-      expect(User.count).to eq(0)
+      expect(User.count).to eq(1)
 
       visit '/'
       click_on 'Login with Spotify'
 
-      user = User.first
+      user = User.last
 
-      expect(User.count).to eq(1)
+      expect(User.count).to eq(2)
       expect(user.username).to eq('test')
       expect(user.access_token).to eq('sample_token')
       expect(user.refresh_token).to eq('sample_refresh_token')
@@ -104,17 +104,17 @@ RSpec.feature 'User logs in with Spotify' do
         .to receive(:request_user_data)
         .and_return(parsed_user_data)
 
-      expect(User.count).to eq(1)
-      expect(User.first.username).to eq('test')
-      expect(User.first.access_token).to eq('1234')
-      expect(User.first.refresh_token).to eq('5678')
+      expect(User.count).to eq(2)
+      expect(User.last.username).to eq('test')
+      expect(User.last.access_token).to eq('1234')
+      expect(User.last.refresh_token).to eq('5678')
 
       visit '/'
       click_on 'Login with Spotify'
 
-      user = User.first
+      user = User.last
 
-      expect(User.count).to eq(1)
+      expect(User.count).to eq(2)
       expect(current_path).to eq(root_path)
       expect(user.username).to eq('test')
       expect(user.access_token).to eq('sample_token')

--- a/spec/features/user_persists_login_after_token_expires_spec.rb
+++ b/spec/features/user_persists_login_after_token_expires_spec.rb
@@ -22,9 +22,9 @@ RSpec.feature 'User persists login after token expires' do
 
     expect(page).to have_link('X')
     expect(page).to_not have_link('Login with Spotify')
-    expect(User.count).to eq(1)
-    expect(User.first.access_token).to eq('new_token')
-    expect(User.first.refresh_token).to eq('new_refresh')
-    expect(User.first.token_expiry).to eq('2016-09-11 22:33:08')
+    expect(User.count).to eq(2)
+    expect(User.last.access_token).to eq('new_token')
+    expect(User.last.refresh_token).to eq('new_refresh')
+    expect(User.last.token_expiry).to eq('2016-09-11 22:33:08')
   end
 end

--- a/spec/features/user_views_their_top_festivals_spec.rb
+++ b/spec/features/user_views_their_top_festivals_spec.rb
@@ -31,11 +31,12 @@ RSpec.describe 'User views their top festivals' do
 
         within("#fest-01") do
           expect(page)
-            .to have_link("Neon Lights Festival 2016")
-          expect(page).to have_content('Foals')
-          expect(page).to have_content('Sigur Rós')
-          expect(page).to have_content('José González')
-          expect(page).to have_content('16+')
+            .to have_link("Primavera Sound Festival 2017")
+          expect(page).to have_content('Local Natives')
+          expect(page).to have_content('Tycho')
+          expect(page).to have_content('Bon Iver')
+          expect(page).to have_content('Angel Olsen')
+          expect(page).to have_content('169+')
         end
 
         expect(page).to_not have_css("#fest-06")
@@ -69,10 +70,15 @@ RSpec.describe 'User views their top festivals' do
 
         within("#fest-01") do
           expect(page)
-            .to have_link("Live 105's Not So Silent Night 2016")
-          expect(page).to have_content('Phantogram')
-          expect(page).to have_content('The Head and the Heart')
-          expect(page).to have_content('11+')
+            .to have_link("Primavera Sound Festival 2017")
+          expect(page).to have_content('Local Natives')
+          expect(page).to have_content('Bon Iver')
+          expect(page).to have_content('Tycho')
+          expect(page).to have_content('Frank Ocean')
+          expect(page).to have_content('Mitski')
+          expect(page).to have_content('Kevin Morby')
+          expect(page).to have_content('Angel Olsen')
+          expect(page).to have_content('166+')
         end
 
         expect(page).to_not have_css("#fest-06")
@@ -106,9 +112,15 @@ RSpec.describe 'User views their top festivals' do
 
         within("#fest-01") do
           expect(page)
-            .to have_link('Laneway Festival 2017')
-          expect(page).to have_content('Tycho')
-          expect(page).to have_content('19+')
+            .to have_link('Primavera Sound Festival 2017')
+          expect(page).to have_content('Bon Iver')
+          expect(page).to have_content('BadBadNotGood')
+          expect(page).to have_content('Run The Jewels')
+          expect(page).to have_content('Mitski')
+          expect(page).to have_content('Local Natives')
+          expect(page).to have_content('Angel Olsen')
+          expect(page).to have_content('Weyes Blood')
+          expect(page).to have_content('166+')
         end
 
         expect(page).to_not have_css("#fest-06")

--- a/spec/features/user_views_their_top_festivals_spec.rb
+++ b/spec/features/user_views_their_top_festivals_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 include SpotifyHelper
 
 RSpec.describe 'User views their top festivals' do
-  before(:all) { refresh_access_token if token_expired? }
+  before(:all) { refresh_access_tokens if token_expired? }
 
   context 'logged-in user for all time top artists' do
     scenario 'they visit the root path', js: true do

--- a/spec/features/user_views_their_top_festivals_spec.rb
+++ b/spec/features/user_views_their_top_festivals_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'User views their top festivals' do
   before(:all) { refresh_access_tokens if token_expired? }
 
   context 'logged-in user for all time top artists' do
-    scenario 'they visit the root path', js: true do
+    scenario 'they view fests, follow/unfollow a playlist', js: true do
       VCR.use_cassette('festival_top_5_all') do
         user = create(:user)
 
@@ -17,7 +17,7 @@ RSpec.describe 'User views their top festivals' do
         click_on 'Top 5 Fests by All Time Top Artists'
 
         # Wait for requests
-        sleep(8)
+        sleep(25)
 
         within('table thead') do
           expect(page).to have_content('Rank')
@@ -27,6 +27,7 @@ RSpec.describe 'User views their top festivals' do
           expect(page).to have_content('Top Artists')
           expect(page).to have_content('Recommended Artists')
           expect(page).to have_content('Other Artists')
+          expect(page).to have_content('Spotify Playlist')
         end
 
         within("#fest-01") do
@@ -35,8 +36,19 @@ RSpec.describe 'User views their top festivals' do
           expect(page).to have_content('Local Natives')
           expect(page).to have_content('Tycho')
           expect(page).to have_content('Bon Iver')
-          expect(page).to have_content('Angel Olsen')
-          expect(page).to have_content('169+')
+          expect(page).to have_content('Kevin Morby')
+          expect(page).to have_content('167+')
+          expect(page).to have_button('Follow')
+
+          click_on 'Follow'
+
+          expect(page).to have_button('Unfollow')
+          expect(page).to_not have_button('Follow')
+
+          click_on 'Unfollow'
+
+          expect(page).to have_button('Follow')
+          expect(page).to_not have_button('Unfollow')
         end
 
         expect(page).to_not have_css("#fest-06")
@@ -45,7 +57,7 @@ RSpec.describe 'User views their top festivals' do
   end
 
   context 'logged-in user for 6 month top artists' do
-    scenario 'they visit the root path', js: true do
+    scenario 'they view fests, follow/unfollow playlist', js: true do
       VCR.use_cassette('festival_top_5_6_months') do
         user = create(:user)
 
@@ -57,7 +69,7 @@ RSpec.describe 'User views their top festivals' do
         click_on "Top 5 Fests by Last 6 Month's Top Artists"
 
         # Wait for requests
-        sleep(8)
+        sleep(25)
 
         within('table thead') do
           expect(page).to have_content('Rank')
@@ -66,6 +78,7 @@ RSpec.describe 'User views their top festivals' do
           expect(page).to have_content('Top Artists')
           expect(page).to have_content('Recommended Artists')
           expect(page).to have_content('Other Artists')
+          expect(page).to have_content('Spotify Playlist')
         end
 
         within("#fest-01") do
@@ -75,10 +88,20 @@ RSpec.describe 'User views their top festivals' do
           expect(page).to have_content('Bon Iver')
           expect(page).to have_content('Tycho')
           expect(page).to have_content('Frank Ocean')
-          expect(page).to have_content('Mitski')
           expect(page).to have_content('Kevin Morby')
           expect(page).to have_content('Angel Olsen')
-          expect(page).to have_content('166+')
+          expect(page).to have_content('168+')
+          expect(page).to have_button('Follow')
+
+          click_on 'Follow'
+
+          expect(page).to have_button('Unfollow')
+          expect(page).to_not have_button('Follow')
+
+          click_on 'Unfollow'
+
+          expect(page).to have_button('Follow')
+          expect(page).to_not have_button('Unfollow')
         end
 
         expect(page).to_not have_css("#fest-06")
@@ -99,7 +122,7 @@ RSpec.describe 'User views their top festivals' do
         click_on "Top 5 Fests by Last 4 Week's Top Artists"
 
         # Wait for requests
-        sleep(8)
+        sleep(25)
 
         within('table thead') do
           expect(page).to have_content('Rank')
@@ -108,19 +131,28 @@ RSpec.describe 'User views their top festivals' do
           expect(page).to have_content('Top Artists')
           expect(page).to have_content('Recommended Artists')
           expect(page).to have_content('Other Artists')
+          expect(page).to have_content('Spotify Playlist')
         end
 
         within("#fest-01") do
           expect(page)
             .to have_link('Primavera Sound Festival 2017')
           expect(page).to have_content('Bon Iver')
-          expect(page).to have_content('BadBadNotGood')
-          expect(page).to have_content('Run The Jewels')
-          expect(page).to have_content('Mitski')
           expect(page).to have_content('Local Natives')
+          expect(page).to have_content('Tycho')
           expect(page).to have_content('Angel Olsen')
-          expect(page).to have_content('Weyes Blood')
-          expect(page).to have_content('166+')
+          expect(page).to have_content('168+')
+          expect(page).to have_button('Follow')
+
+          click_on 'Follow'
+
+          expect(page).to have_button('Unfollow')
+          expect(page).to_not have_button('Follow')
+
+          click_on 'Unfollow'
+
+          expect(page).to have_button('Follow')
+          expect(page).to_not have_button('Unfollow')
         end
 
         expect(page).to_not have_css("#fest-06")
@@ -128,7 +160,7 @@ RSpec.describe 'User views their top festivals' do
     end
   end
 
-  context 'logged-in user no top artists with festivals' do
+  context 'logged-in user no festivals' do
     scenario 'they visit the root path', js: true do
       VCR.use_cassette('festival_top_5_none') do
         user = create(:user)

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 include SpotifyHelper
 
 describe Artist do
-  before(:all) { refresh_access_token if token_expired? }
+  before(:all) { refresh_access_tokens if token_expired? }
 
   it "gets a user's top artists with complete profiles" do
     VCR.use_cassette('artist_top_artists_complete') do

--- a/spec/models/festival_spec.rb
+++ b/spec/models/festival_spec.rb
@@ -14,7 +14,7 @@ describe Festival do
         expect(top_5_fests.length).to eq(5)
         expect(top_5_fests.first).to be_a(Festival)
         expect(top_5_fests.first.score).to be <= top_5_fests.second.score
-        expect(top_5_fests.first.location).to eq('Singapore, Singapore')
+        expect(top_5_fests.first.location).to eq('Barcelona, Spain')
         expect(top_5_fests.first.other_artists_count).to be > 1
       end
     end

--- a/spec/models/festival_spec.rb
+++ b/spec/models/festival_spec.rb
@@ -8,6 +8,10 @@ describe Festival do
     it "returns the top 5 fests based on top and recommended artists" do
       VCR.use_cassette('festival_top_5_all') do
         user = create(:user)
+        playlist = Playlist.create!(
+          name: 'Primavera Sound Festival 2017',
+          spotify_id: 'test'
+        )
         all_artists = Artist.all(user, 'long_term')
         top_5_fests = Festival.top_festivals(all_artists)
 
@@ -16,6 +20,8 @@ describe Festival do
         expect(top_5_fests.first.score).to be <= top_5_fests.second.score
         expect(top_5_fests.first.location).to eq('Barcelona, Spain')
         expect(top_5_fests.first.other_artists_count).to be > 1
+        expect(top_5_fests.first.playlist).to be_a(Playlist)
+        expect(top_5_fests.first.playlist.spotify_id).to eq('test')
       end
     end
   end

--- a/spec/models/festival_spec.rb
+++ b/spec/models/festival_spec.rb
@@ -2,16 +2,12 @@ require 'rails_helper'
 include SpotifyHelper
 
 describe Festival do
-  before(:all) { refresh_access_token if token_expired? }
+  before(:all) { refresh_access_tokens if token_expired? }
 
   context 'with artists present' do
     it "returns the top 5 fests based on top and recommended artists" do
       VCR.use_cassette('festival_top_5_all') do
         user = create(:user)
-        playlist = Playlist.create!(
-          name: 'Primavera Sound Festival 2017',
-          spotify_id: 'test'
-        )
         all_artists = Artist.all(user, 'long_term')
         top_5_fests = Festival.top_festivals(all_artists)
 
@@ -20,8 +16,6 @@ describe Festival do
         expect(top_5_fests.first.score).to be <= top_5_fests.second.score
         expect(top_5_fests.first.location).to eq('Barcelona, Spain')
         expect(top_5_fests.first.other_artists_count).to be > 1
-        expect(top_5_fests.first.playlist).to be_a(Playlist)
-        expect(top_5_fests.first.playlist.spotify_id).to eq('test')
       end
     end
   end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -11,15 +11,16 @@ RSpec.describe Playlist, type: :model do
     list = Playlist.create!(name: 'test', spotify_id: 'unique_id')
 
     expect(Playlist.count).to eq(1)
-    expect(Playlist.find_or_create({ displayName: 'test' })).to eq(list)
+    expect(Playlist.find_or_create(
+      Festival.new({ displayName: 'test' })
+    )).to eq(list)
 
     allow_any_instance_of(PlaylistEngine)
       .to receive(:create_playlist)
       .and_return('1')
-    other = Playlist.find_or_create({
-      displayName: 'none',
-      performance: []
-    })
+    other = Playlist.find_or_create(
+      Festival.new({ displayName: 'none', performance: [] })
+    )
 
     expect(Playlist.count).to eq(2)
     expect(other.spotify_id).to eq('1')

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Playlist, type: :model do
 
     expect(Playlist.count).to eq(1)
     expect(Playlist.find_or_create(
-      Festival.new({ displayName: 'test' })
+      Festival.new(displayName: 'test' )
     )).to eq(list)
 
     allow_any_instance_of(PlaylistEngine)
       .to receive(:create_playlist)
       .and_return('1')
     other = Playlist.find_or_create(
-      Festival.new({ displayName: 'none', performance: [] })
+      Festival.new(displayName: 'none', performance: [])
     )
 
     expect(Playlist.count).to eq(2)

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -4,4 +4,25 @@ RSpec.describe Playlist, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:spotify_id) }
   it { should validate_uniqueness_of(:spotify_id) }
+
+  it 'finds or creates a playlist from festival data' do
+    expect(Playlist.count).to eq(0)
+
+    list = Playlist.create!(name: 'test', spotify_id: 'unique_id')
+
+    expect(Playlist.count).to eq(1)
+    expect(Playlist.find_or_create({ displayName: 'test' })).to eq(list)
+
+    allow_any_instance_of(PlaylistEngine)
+      .to receive(:create_playlist)
+      .and_return('1')
+    other = Playlist.find_or_create({
+      displayName: 'none',
+      performance: []
+    })
+
+    expect(Playlist.count).to eq(2)
+    expect(other.spotify_id).to eq('1')
+    expect(other.name).to eq('none')
+  end
 end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Playlist, type: :model do
+  it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:spotify_id) }
+  it { should validate_uniqueness_of(:spotify_id) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe User, type: :model do
   it { should validate_presence_of(:access_token) }
   it { should validate_presence_of(:refresh_token) }
   it { should validate_presence_of(:token_expiry) }
+
+  it "can return the site admin" do
+    admin = User.site_admin
+    expect(admin).to be_a(User)
+    expect(admin.username).to eq('festsuggest')
+  end
 end

--- a/spec/requests/artists_request_spec.rb
+++ b/spec/requests/artists_request_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 include SpotifyHelper
 
 RSpec.describe ArtistsController, type: :request do
-  before(:all) { refresh_access_token if token_expired? }
+  before(:all) { refresh_access_tokens if token_expired? }
 
   it 'returns artists for long_term range' do
     VCR.use_cassette('artist_controller_long_term') do

--- a/spec/requests/festivals_request_spec.rb
+++ b/spec/requests/festivals_request_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 include SpotifyHelper
 
 RSpec.describe FestivalsController, type: :request do
-  before(:all) { refresh_access_token if token_expired? }
+  before(:all) { refresh_access_tokens if token_expired? }
 
   it 'returns festivals for long_term range' do
     VCR.use_cassette('festival_controller_long_term') do

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -141,4 +141,63 @@ RSpec.describe 'Spotify service' do
       end
     end
   end
+
+  context '#user_following_playlist?' do
+    it 'returns a boolean value for if a user follows a playlist' do
+      VCR.use_cassette('spotify_service_user_following_playlist') do
+        service = Spotify::Service.new(ENV['FS_ACCESS_TOKEN'])
+        playlist_id = service.create_playlist('test2')
+        result = service.user_following_playlist?(
+          ENV['SPOTIFY_USERNAME'], playlist_id
+        )
+
+        expect(result).to eq(false)
+      end
+    end
+  end
+
+  context '#follow_playlist' do
+    it "adds a playlist to the user's public playlists" do
+      VCR.use_cassette('spotify_service_follow_playlist') do
+        playlist_id = Spotify::Service.new(ENV['FS_ACCESS_TOKEN'])
+                                      .create_playlist('test follow')
+        service = Spotify::Service.new(ENV['ACCESS_TOKEN'])
+        following_before = service.user_following_playlist?(
+          ENV['SPOTIFY_USERNAME'], playlist_id
+        )
+
+        expect(following_before).to eq(false)
+
+        service.follow_playlist(playlist_id)
+        following_after = service.user_following_playlist?(
+          ENV['SPOTIFY_USERNAME'], playlist_id
+        )
+
+        expect(following_after).to eq(true)
+      end
+    end
+  end
+
+  context '#unfollow_playlist' do
+    it "removes a followed playlist from the user's public playlists" do
+      VCR.use_cassette('spotify_service_unfollow_playlist') do
+        playlist_id = Spotify::Service.new(ENV['FS_ACCESS_TOKEN'])
+                                      .create_playlist('test unfollow')
+        service = Spotify::Service.new(ENV['ACCESS_TOKEN'])
+        service.follow_playlist(playlist_id)
+        following_before = service.user_following_playlist?(
+          ENV['SPOTIFY_USERNAME'], playlist_id
+        )
+
+        expect(following_before).to eq(true)
+
+        service.unfollow_playlist(playlist_id)
+        following_after = service.user_following_playlist?(
+          ENV['SPOTIFY_USERNAME'], playlist_id
+        )
+
+        expect(following_after).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Spotify service' do
   context '#each_artists_top_track' do
     it 'returns an array of one Spotify track URI for each ID' do
       VCR.use_cassette('spotify_service_each_artists_top_track') do
-        ids = ['4MXUO7sVCaFgFjoTI5ox5c', '6CwDvApcRshxhEVMP30Sq7']
+        ids = %w(4MXUO7sVCaFgFjoTI5ox5c 6CwDvApcRshxhEVMP30Sq7)
         uris = Spotify::Service.new(ENV['ACCESS_TOKEN'])
                                .each_artists_top_track(ids)
 
@@ -118,10 +118,7 @@ RSpec.describe 'Spotify service' do
       VCR.use_cassette('spotify_service_add_tracks_to_playlist') do
         service = Spotify::Service.new(ENV['FS_ACCESS_TOKEN'])
         playlist_id = service.create_playlist('test')
-        artist_ids = [
-          '4MXUO7sVCaFgFjoTI5ox5c',
-          '6CwDvApcRshxhEVMP30Sq7'
-        ]
+        artist_ids = %w(4MXUO7sVCaFgFjoTI5ox5c 6CwDvApcRshxhEVMP30Sq7)
         track_uris = service.each_artists_top_track(artist_ids)
         response =
           service.add_tracks_to_playlist(playlist_id, track_uris)

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 include SpotifyHelper
 
 RSpec.describe 'Spotify service' do
-  before(:all) { refresh_access_token if token_expired? }
+  before(:all) { refresh_access_tokens if token_expired? }
 
   context '#get_username' do
     it "gets a user's username" do
@@ -70,6 +70,74 @@ RSpec.describe 'Spotify service' do
         expect(recommended.length).to eq(100)
         expect(recommended.first[:artists].first[:name])
           .to eq('Wye Oak')
+      end
+    end
+  end
+
+  context '#create_playlist' do
+    it 'creates a playlist and returns its Spotify ID' do
+      VCR.use_cassette('spotify_service_create_playlist') do
+        id = Spotify::Service.new(ENV['FS_ACCESS_TOKEN'])
+                             .create_playlist('test')
+
+        expect(id).to be_a(String)
+      end
+    end
+  end
+
+  context '#all_artist_ids' do
+    it 'returns an array of Spotify IDs from a collection of names' do
+      VCR.use_cassette('spotify_service_all_artist_ids') do
+        artists = ['Sufjan Stevens', 'Ryan Flach', 'Team Sleep']
+        ids = Spotify::Service.new(ENV['ACCESS_TOKEN'])
+                              .all_artist_ids(artists)
+
+        expect(ids).to be_a(Array)
+        expect(ids.length).to eq(2)
+        expect(ids.first).to eq('4MXUO7sVCaFgFjoTI5ox5c')
+      end
+    end
+  end
+
+  context '#each_artists_top_track' do
+    it 'returns an array of one Spotify track URI for each ID' do
+      VCR.use_cassette('spotify_service_each_artists_top_track') do
+        ids = ['4MXUO7sVCaFgFjoTI5ox5c', '6CwDvApcRshxhEVMP30Sq7']
+        uris = Spotify::Service.new(ENV['ACCESS_TOKEN'])
+                               .each_artists_top_track(ids)
+
+        expect(uris).to be_a(Array)
+        expect(uris.length).to eq(2)
+        expect(uris.first).to eq('spotify:track:6Rt6KwuF7I8ZkdZG2G0bYr')
+      end
+    end
+  end
+
+  context '#add_tracks_to_playlist' do
+    it 'adds tracks from Spotify URIs to an existing playlist' do
+      VCR.use_cassette('spotify_service_add_tracks_to_playlist') do
+        service = Spotify::Service.new(ENV['FS_ACCESS_TOKEN'])
+        playlist_id = service.create_playlist('test')
+        artist_ids = [
+          '4MXUO7sVCaFgFjoTI5ox5c',
+          '6CwDvApcRshxhEVMP30Sq7'
+        ]
+        track_uris = service.each_artists_top_track(artist_ids)
+        response =
+          service.add_tracks_to_playlist(playlist_id, track_uris)
+        playlist = Typhoeus::Request.new(
+          "#{service.instance_variable_get('@base_url')}/v1/users/" \
+          "#{ENV['FS_ADMIN_NAME']}/playlists/#{playlist_id}/tracks",
+          headers: service.instance_variable_get('@headers')
+        ).run
+        tracks_on_playlist = JSON.parse(
+          playlist.response_body, symbolize_names: true
+        )[:items]
+
+        expect(response).to be_a(Hash)
+        expect(tracks_on_playlist.length).to eq(2)
+        expect(tracks_on_playlist.first[:track][:uri])
+          .to eq(track_uris.first)
       end
     end
   end

--- a/spec/support/spotify_helper.rb
+++ b/spec/support/spotify_helper.rb
@@ -3,19 +3,25 @@ module SpotifyHelper
     ENV['TOKEN_EXPIRY'] < Time.now
   end
 
-  def refresh_access_token
-    new_tokens = Spotify::AuthService.new
-                                     .refresh_user_tokens(
-                                       ENV['REFRESH_TOKEN']
-                                     )
-    update_yml_file(new_tokens)
+  def refresh_access_tokens
+    refresh_access_token('base')
+    refresh_access_token('site')
   end
 
-  def update_yml_file(tokens)
+  def refresh_access_token(user)
+    prefix = user == 'base' ? nil : 'FS_'
+    new_tokens = Spotify::AuthService.new
+                                     .refresh_user_tokens(
+                                       ENV["#{prefix}REFRESH_TOKEN"]
+                                     )
+    update_yml_file(new_tokens, prefix)
+  end
+
+  def update_yml_file(tokens, prefix)
     data = YAML.load_file('config/application.yml')
-    data['test']['ACCESS_TOKEN'] = tokens[:access_token]
-    data['test']['TOKEN_EXPIRY'] = tokens[:token_expiry]
-    data['test']['REFRESH_TOKEN'] =
+    data['test']["#{prefix}ACCESS_TOKEN"] = tokens[:access_token]
+    data['test']["#{prefix}TOKEN_EXPIRY"] = tokens[:token_expiry]
+    data['test']["#{prefix}REFRESH_TOKEN"] =
       tokens[:refresh_token] if tokens[:refresh_token]
     File.open('config/application.yml', 'w') do |file|
       YAML.dump(data, file)


### PR DESCRIPTION
Allows a user to follow or unfollow a Spotify playlist of up to 100 tracks (each festival artist's [up to 100] top track) for each festival.

Maintains login state of an additional Spotify account (site admin) for creation of playlists on Spotify.
Utilizes a background worker to add tracks to created playlists. 
- Background worker operates in serial and has built-in sleep functions. This is due to rate limitations with the Spotify API.
Created playlists are tracked in a local database.